### PR TITLE
fix: fix recordHostChildrenToDelete for fragment deletion

### DIFF
--- a/packages/react-reconciler/src/commitWork.ts
+++ b/packages/react-reconciler/src/commitWork.ts
@@ -25,7 +25,8 @@ import {
 	FunctionComponent,
 	HostComponent,
 	HostRoot,
-	HostText
+	HostText,
+	Fragment
 } from './workTags';
 
 let nextEffect: FiberNode | null = null;
@@ -267,22 +268,23 @@ function getHostParent(fiber: FiberNode) {
 	console.error('getHostParent未找到hostParent');
 }
 
-function recordHostChildrenToDelete(
-	hostChildrenToDelete: FiberNode[],
-	unmountFiber: FiberNode
-) {
-	const lastOne = hostChildrenToDelete[hostChildrenToDelete.length - 1];
-	if (!lastOne) {
-		hostChildrenToDelete.push(unmountFiber);
-	} else {
-		let node = lastOne.sibling;
-		while (node !== null) {
-			if (unmountFiber === node) {
-				hostChildrenToDelete.push(unmountFiber);
-			}
-			node = node.sibling;
+function recordHostChildrenToDelete(beginNode: FiberNode): FiberNode[] {
+	if (beginNode.tag !== Fragment) return [beginNode];
+	const hostChildrenToDelete: FiberNode[] = [];
+	const processQueue: FiberNode[] = [beginNode];
+	while (processQueue.length) {
+		const node = processQueue.shift();
+		if (node && node.tag !== Fragment) {
+			hostChildrenToDelete.push(node);
+			continue;
+		}
+		let childNode = node?.child;
+		while (childNode) {
+			processQueue.push(childNode);
+			childNode = childNode.sibling;
 		}
 	}
+	return hostChildrenToDelete;
 }
 
 /**
@@ -295,24 +297,25 @@ function commitDeletion(childToDelete: FiberNode, root: FiberRootNode) {
 		console.log('删除DOM、组件unmount', childToDelete);
 	}
 	// 在Fragment之前，只需删除子树的根Host节点，但支持Fragment后，可能需要删除同级多个节点
-	const hostChildrenToDelete: FiberNode[] = [];
+	const hostChildrenToDelete: FiberNode[] =
+		recordHostChildrenToDelete(childToDelete);
 
-	commitNestedUnmounts(childToDelete, (unmountFiber) => {
-		switch (unmountFiber.tag) {
-			case HostComponent:
-				recordHostChildrenToDelete(hostChildrenToDelete, unmountFiber);
-				// 解绑ref
-				safelyDetachRef(unmountFiber);
-				return;
-			case HostText:
-				recordHostChildrenToDelete(hostChildrenToDelete, unmountFiber);
-				return;
-			case FunctionComponent:
-				// effect相关操作
-				commitPassiveEffect(unmountFiber, root, 'unmount');
-				return;
-		}
-	});
+	for (let i = 0; i < hostChildrenToDelete.length; i++) {
+		commitNestedUnmounts(hostChildrenToDelete[i], (unmountFiber) => {
+			switch (unmountFiber.tag) {
+				case HostComponent:
+					// 解绑ref
+					safelyDetachRef(unmountFiber);
+					return;
+				case HostText:
+					return;
+				case FunctionComponent:
+					// effect相关操作
+					commitPassiveEffect(unmountFiber, root, 'unmount');
+					return;
+			}
+		});
+	}
 
 	if (hostChildrenToDelete.length) {
 		const hostParent = getHostParent(childToDelete) as Container;


### PR DESCRIPTION
原代码中标记Fragment下需要被删除的元素时，没有考虑到Fragment嵌套的情况，会导致部分待删除元素被忽略，可用原代码运行如下组件进行复现：
```
function App() {
	const [num, setNum] = useState(0);

	return (
		<ul onClick={() => setNum((prevNum) => prevNum + 1)}>
			<li>a</li>
			<li>b</li>
			{num % 2 === 0 ? (
				<>
					<li>item-1</li>
					<>
						<li>item-2</li>
						<>
							<li>item-3</li>
							<li>item-4</li>
						</>
						<li>item-5</li>
					</>
					<li>item</li>
				</>
			) : (
				<li>test</li>
			)}
			<li>c</li>
			<li>d</li>
		</ul>
	);
}
```
改进策略为：修改recordHostChildrenToDelete，通过BFS标记各层Fragment下需要删除的元素，并将recordHostChildrenToDelete与commitNestedUnmounts解耦，增强代码可读性。