### PR TITLE
fix: react.config.js output formate -> format

### DIFF
--- a/scripts/rollup/react.config.js
+++ b/scripts/rollup/react.config.js
@@ -38,13 +38,13 @@ export default [
 			{
 				file: `${pkgDistPath}/jsx-runtime.js`,
 				name: 'jsx-runtime',
-				formate: 'umd'
+				format: 'umd'
 			},
 			// jsx-dev-runtime
 			{
 				file: `${pkgDistPath}/jsx-dev-runtime.js`,
 				name: 'jsx-dev-runtime',
-				formate: 'umd'
+				format: 'umd'
 			}
 		],
 		plugins: getBaseRollupPlugins()


### PR DESCRIPTION
使用 formate时，打包提示
<img width="432" alt="image" src="https://github.com/BetaSu/big-react/assets/20721540/49e3d0fa-55b6-49d9-bb40-ed3a761252bd">
<img width="1175" alt="image" src="https://github.com/BetaSu/big-react/assets/20721540/be35df6c-82b4-4049-8fcb-615d9370c004">
查了下这个文档 https://rollupjs.org/configuration-options/#output-format 
这里应该是写错了 所以把 formate 改成了 format
