### PR TITLE
fix: 去掉了workTags.ts中LazyComponent后多余的";"

### DIFF
--- a/packages/react-reconciler/src/workTags.ts
+++ b/packages/react-reconciler/src/workTags.ts
@@ -7,7 +7,7 @@ export type WorkTag =
 	| typeof ContextProvider
 	| typeof SuspenseComponent
 	| typeof OffscreenComponent
-	| typeof LazyComponent;
+	| typeof LazyComponent
 	| typeof MemoComponent;
 
 export const FunctionComponent = 0;


### PR DESCRIPTION
<img width="322" alt="image" src="https://github.com/BetaSu/big-react/assets/20721540/33c6cce6-3baa-43bc-b7a3-cc04c0529a4f">
<img width="807" alt="image" src="https://github.com/BetaSu/big-react/assets/20721540/5fec837b-0a2e-47e6-a8cd-351d5fca4227">
